### PR TITLE
Fix: uploadId str() casting + FastMCP description kwarg compatibility

### DIFF
--- a/easy_fossy/__init__.py
+++ b/easy_fossy/__init__.py
@@ -1230,7 +1230,7 @@ class easy_fossy:
         headers = {
             "accept": "application/json",
             "folderId": str(folder_id),
-            "uploadId": upload_id,
+            "uploadId": str(upload_id),
             "groupName": self.group_name,
             "Content-Type": "application/json",
             "Authorization": self.bearer_token,
@@ -1770,7 +1770,7 @@ class easy_fossy:
             "accept": "application/json",
             "groupName": self.group_name,
             "searchType": searchType.name,
-            "uploadId": uploadId,
+            "uploadId": str(uploadId),
             "filename": filename_wildcard,
             "tag": tag,
             "filesizemin": filesizemin_bytes,

--- a/server.py
+++ b/server.py
@@ -31,8 +31,7 @@ from pydantic import BaseModel, Field
 # Create an MCP server with description
 mcp = FastMCP(
     "EasyFossy", 
-    description="Model Context Protocol server for Fossology license scanning and management"
-)
+    )
 
 # Initialize easy_fossy instance
 fossy = None

--- a/serversse.py
+++ b/serversse.py
@@ -31,7 +31,6 @@ from pydantic import BaseModel, Field
 # Create an MCP server with description
 mcp = FastMCP(
     "EasyFossy", 
-    description="Model Context Protocol server for Fossology license scanning and management, port localhost:8050",
     host="0.0.0.0",  # only used for SSE transport
     port=8050,  # only used for SSE transport (set this to any port)
 )


### PR DESCRIPTION
Hi Dinesh,

Thank you for the great project! As discussed in https://github.com/dineshr93/easy_fossy/discussions/4, here are the fixes:

### 1. Cast uploadId to str() in headers (easy_fossy/__init__.py)
- Line 1233: `"uploadId": upload_id` → `"uploadId": str(upload_id)`
- Line 1773: `"uploadId": uploadId` → `"uploadId": str(uploadId)`

HTTP headers require string values. Found that `folderId` (line 1232) and other `uploadId` usages (line 543) already correctly use `str()`. Updated both instances for consistency.

### 2. Remove unsupported description kwarg from FastMCP (server.py, serversse.py)
`FastMCP()` no longer accepts `description=` keyword argument since mcp>=1.12.3, causing TypeError on startup.
Reference: modelcontextprotocol/python-sdk#1234

Happy to make any changes if needed. Thanks for your time!

Thanks,
Bharath